### PR TITLE
Allow models to define a method which will be called before bulk-saving them.

### DIFF
--- a/bulktest/models.py
+++ b/bulktest/models.py
@@ -5,3 +5,12 @@ class TestModelA(models.Model):
     a = models.CharField(max_length=200)
     b = models.IntegerField()
     c = models.IntegerField()
+
+
+class TestModelPreSave(models.Model):
+    """Model that defines the presave method."""
+
+    a = models.IntegerField()
+
+    def presave(self):
+        self.a = 5

--- a/bulktest/tests.py
+++ b/bulktest/tests.py
@@ -1,5 +1,5 @@
 from django.test import TestCase
-from bulktest.models import TestModelA
+from bulktest.models import TestModelA, TestModelPreSave
 from djangobulk.bulk import insert_many, update_many, insert_or_update_many
 
 
@@ -185,3 +185,13 @@ class InsertUpdateTest(TestCase):
         insert_or_update_many(TestModelA, set1, keys=['b'])
         self.assertEqual(2, TestModelA.objects.all().count())
         self.assertEqual(3, TestModelA.objects.get(a="Test2").c)
+
+
+class TestPreSave(TestCase):
+    """Test the presave() method support."""
+
+    def test_presave_called(self):
+        m = TestModelPreSave()
+        m.a = 3
+        insert_many(TestModelPreSave, [m])
+        self.assertEquals(m.a, 5)

--- a/bulktest/tests.py
+++ b/bulktest/tests.py
@@ -164,6 +164,30 @@ class InsertUpdateTest(TestCase):
         self.assertEqual(3, TestModelA.objects.get(a="Test1", b=1).c)
         self.assertEqual(3, TestModelA.objects.get(a="Test3", b=3).c)
 
+
+    def test_multikey_insert_skip_update(self):
+        # Expected to fail in SQLite (no tuple comparison)
+        set1 = [
+            TestModelA(a="Test1", b=1, c=1),
+            TestModelA(a="Test2", b=2, c=2),
+            ]
+
+        insert_many(TestModelA, set1)
+        self.assertEqual(2, TestModelA.objects.all().count())
+
+        set2 = [
+            TestModelA(a="Test1", b=1, c=3),
+            TestModelA(a="Test2", b=3, c=4),
+            TestModelA(a="Test3", b=3, c=3),
+            ]
+
+        insert_or_update_many(TestModelA, set2, keys=['a', 'b'], skip_update=True)
+        self.assertEqual(4, TestModelA.objects.all().count())
+        self.assertEqual(2, TestModelA.objects.filter(a="Test2").count())
+
+        self.assertEqual(1, TestModelA.objects.get(a="Test1", b=1).c)
+        self.assertEqual(3, TestModelA.objects.get(a="Test3", b=3).c)
+
     def test_big_insert_update(self):
         # Expected to fail in SQLite (too many variables)
         set1 = [TestModelA(a="Test", b=i, c=1) for i in range(1000)]

--- a/djangobulk/bulk.py
+++ b/djangobulk/bulk.py
@@ -38,7 +38,7 @@ def _insert_many(model, objects, using="default"):
     con.cursor().executemany(sql, parameters)
 
 
-def insert_many(*args, **kwargs):
+def insert_many(model, objects, using="default"):
     '''
     Bulk insert list of Django objects. Objects must be of the same
     Django model.
@@ -51,8 +51,8 @@ def insert_many(*args, **kwargs):
     :param using: Database to use.
 
     '''
-    _insert_many(*args, **kwargs)
-    transaction.commit_unless_managed()
+    _insert_many(model, objects, using)
+    transaction.commit_unless_managed(using)
 
 
 def _update_many(model, objects, keys=None, using="default"):
@@ -85,7 +85,7 @@ def _update_many(model, objects, keys=None, using="default"):
     con.cursor().executemany(sql, parameters)
 
 
-def update_many(*args, **kwargs):
+def update_many(model, objects, keys=None, using="default"):
     '''
     Bulk update list of Django objects. Objects must be of the same
     Django model.
@@ -99,8 +99,8 @@ def update_many(*args, **kwargs):
     :param using: Database to use.
 
     '''
-    _update_many(*args, **kwargs)
-    transaction.commit_unless_managed()
+    _update_many(model, objects, keys, using)
+    transaction.commit_unless_managed(using)
 
 
 def _filter_objects(con, objects, key_fields):
@@ -168,4 +168,4 @@ def insert_or_update_many(model, objects, keys=None, using="default"):
     filtered_objects = _filter_objects(con, insert_objects, key_fields)
 
     _insert_many(model, filtered_objects, using=using)
-    transaction.commit_unless_managed()
+    transaction.commit_unless_managed(using)

--- a/djangobulk/bulk.py
+++ b/djangobulk/bulk.py
@@ -15,6 +15,8 @@ def _model_fields(model):
 
 
 def _prep_values(fields, obj, con):
+    if hasattr(obj, 'presave') and callable(obj.presave):
+        obj.presave()
     return tuple(f.get_db_prep_save(f.pre_save(obj, True), connection=con)
                  for f in fields)
 

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 from distutils.core import setup
 
 setup(
-    name='djangobulk',
-    version='0.1',
+    name='django-bulk',
+    version='0.1devel',
     author='Kevin Mahoney',
     author_email='kevin.mahoney@maplecroft.com',
     packages=['djangobulk'],


### PR DESCRIPTION
Many models override `save()` to do some extra work, before commiting them to the database.
So, we add support for a `presave()` method of the model, which will be called, whenever we insert a new object or update an existing one.
